### PR TITLE
Update specInvFft.m

### DIFF
--- a/main/specInvFft.m
+++ b/main/specInvFft.m
@@ -16,7 +16,7 @@ if nargin<2
     dim = 1;
 end
 
-fid = ifft(fftshift(spec,dim),[],dim)*size(spec,dim);
+fid = ifft(ifftshift(spec,dim),[],dim)*size(spec,dim);
 
 perm = [dim 1:(dim-1) (dim+1):numel(size(fid))];
 


### PR DESCRIPTION
In the case that `spec` has an odd number of elements, `ifft(fftshift(spec))` will cause a time shift. Change it to `ifft(ifftshift(spec))`